### PR TITLE
async support with feature

### DIFF
--- a/embedded-cli-macros/Cargo.toml
+++ b/embedded-cli-macros/Cargo.toml
@@ -20,6 +20,8 @@ default = []
 autocomplete = []
 help = []
 
+async = []
+
 [dependencies]
 convert_case = "0.6.0"
 darling = "0.20.8"

--- a/embedded-cli-macros/src/processor.rs
+++ b/embedded-cli-macros/src/processor.rs
@@ -10,45 +10,91 @@ pub fn impl_processor(vis: &Visibility, target: &TargetType) -> Result<TokenStre
     let named_lifetime = target.named_lifetime();
     let unnamed_lifetime = target.unnamed_lifetime();
 
-    let output = quote! {
+    let output = if cfg!(feature = "async") {
+        quote! {
 
-        impl #named_lifetime #ident #named_lifetime {
-            #vis fn processor<
-                W: _io::Write<Error = E>,
-                E: _io::Error,
-                F: FnMut(&mut _cli::cli::CliHandle<'_, W, E>, #ident #unnamed_lifetime) -> Result<(), E>,
-            >(
-                f: F,
-            ) -> impl _cli::service::CommandProcessor<W, E> {
-                struct Processor<
+            impl #named_lifetime #ident #named_lifetime {
+                #vis fn processor<
+                    W: _io::Write<Error = E>,
+                    E: _io::Error,
+                    F: AsyncFnMut(&mut _cli::cli::CliHandle<'_, W, E>, #ident #unnamed_lifetime) -> Result<(), E>,
+                >(
+                    f: F,
+                ) -> impl _cli::service::CommandProcessor<W, E> {
+                    struct Processor<
+                        W: _io::Write<Error = E>,
+                        E: _io::Error,
+                        F: AsyncFnMut(&mut _cli::cli::CliHandle<'_, W, E>, #ident #unnamed_lifetime) -> Result<(), E>,
+                    > {
+                        f: F,
+                        _ph: core::marker::PhantomData<(W, E)>,
+                    }
+
+                    impl<
+                            W: _io::Write<Error = E>,
+                            E: _io::Error,
+                            F: AsyncFnMut(&mut _cli::cli::CliHandle<'_, W, E>, #ident #unnamed_lifetime) -> Result<(), E>,
+                        > _cli::service::CommandProcessor<W, E> for Processor<W, E, F>
+                    {
+                        async fn process<'a>(
+                            &mut self,
+                            cli: &mut _cli::cli::CliHandle<'_, W, E>,
+                            raw: _cli::command::RawCommand<'a>,
+                        ) -> Result<(), _cli::service::ProcessError<'a, E>> {
+                            let cmd = <#ident #unnamed_lifetime as _cli::service::FromRaw>::parse(raw)?;
+                            (self.f)(cli, cmd).await?;
+                            Ok(())
+                        }
+                    }
+
+                    Processor {
+                        f,
+                        _ph: core::marker::PhantomData,
+                    }
+                }
+            }
+        }
+    } else {
+        quote! {
+
+            impl #named_lifetime #ident #named_lifetime {
+                #vis fn processor<
                     W: _io::Write<Error = E>,
                     E: _io::Error,
                     F: FnMut(&mut _cli::cli::CliHandle<'_, W, E>, #ident #unnamed_lifetime) -> Result<(), E>,
-                > {
+                >(
                     f: F,
-                    _ph: core::marker::PhantomData<(W, E)>,
-                }
-
-                impl<
+                ) -> impl _cli::service::CommandProcessor<W, E> {
+                    struct Processor<
                         W: _io::Write<Error = E>,
                         E: _io::Error,
                         F: FnMut(&mut _cli::cli::CliHandle<'_, W, E>, #ident #unnamed_lifetime) -> Result<(), E>,
-                    > _cli::service::CommandProcessor<W, E> for Processor<W, E, F>
-                {
-                    fn process<'a>(
-                        &mut self,
-                        cli: &mut _cli::cli::CliHandle<'_, W, E>,
-                        raw: _cli::command::RawCommand<'a>,
-                    ) -> Result<(), _cli::service::ProcessError<'a, E>> {
-                        let cmd = <#ident #unnamed_lifetime as _cli::service::FromRaw>::parse(raw)?;
-                        (self.f)(cli, cmd)?;
-                        Ok(())
+                    > {
+                        f: F,
+                        _ph: core::marker::PhantomData<(W, E)>,
                     }
-                }
 
-                Processor {
-                    f,
-                    _ph: core::marker::PhantomData,
+                    impl<
+                            W: _io::Write<Error = E>,
+                            E: _io::Error,
+                            F: FnMut(&mut _cli::cli::CliHandle<'_, W, E>, #ident #unnamed_lifetime) -> Result<(), E>,
+                        > _cli::service::CommandProcessor<W, E> for Processor<W, E, F>
+                    {
+                        fn process<'a>(
+                            &mut self,
+                            cli: &mut _cli::cli::CliHandle<'_, W, E>,
+                            raw: _cli::command::RawCommand<'a>,
+                        ) -> Result<(), _cli::service::ProcessError<'a, E>> {
+                            let cmd = <#ident #unnamed_lifetime as _cli::service::FromRaw>::parse(raw)?;
+                            (self.f)(cli, cmd)?;
+                            Ok(())
+                        }
+                    }
+
+                    Processor {
+                        f,
+                        _ph: core::marker::PhantomData,
+                    }
                 }
             }
         }

--- a/embedded-cli-macros/src/processor.rs
+++ b/embedded-cli-macros/src/processor.rs
@@ -10,17 +10,19 @@ pub fn impl_processor(vis: &Visibility, target: &TargetType) -> Result<TokenStre
     let named_lifetime = target.named_lifetime();
     let unnamed_lifetime = target.unnamed_lifetime();
 
-    let output = if cfg!(feature = "async") {
-        quote! {
+    let mut output = TokenStream::new();
+
+    if cfg!(feature = "async") {
+        output.extend(quote! {
 
             impl #named_lifetime #ident #named_lifetime {
-                #vis fn processor<
+                #vis fn processor_async<
                     W: _io::Write<Error = E>,
                     E: _io::Error,
                     F: AsyncFnMut(&mut _cli::cli::CliHandle<'_, W, E>, #ident #unnamed_lifetime) -> Result<(), E>,
                 >(
                     f: F,
-                ) -> impl _cli::service::CommandProcessor<W, E> {
+                ) -> impl _cli::service::CommandProcessorAsync<W, E> {
                     struct Processor<
                         W: _io::Write<Error = E>,
                         E: _io::Error,
@@ -34,7 +36,7 @@ pub fn impl_processor(vis: &Visibility, target: &TargetType) -> Result<TokenStre
                             W: _io::Write<Error = E>,
                             E: _io::Error,
                             F: AsyncFnMut(&mut _cli::cli::CliHandle<'_, W, E>, #ident #unnamed_lifetime) -> Result<(), E>,
-                        > _cli::service::CommandProcessor<W, E> for Processor<W, E, F>
+                        > _cli::service::CommandProcessorAsync<W, E> for Processor<W, E, F>
                     {
                         async fn process<'a>(
                             &mut self,
@@ -53,8 +55,9 @@ pub fn impl_processor(vis: &Visibility, target: &TargetType) -> Result<TokenStre
                     }
                 }
             }
-        }
-    } else {
+        })
+    };
+    output.extend(
         quote! {
 
             impl #named_lifetime #ident #named_lifetime {
@@ -98,7 +101,7 @@ pub fn impl_processor(vis: &Visibility, target: &TargetType) -> Result<TokenStre
                 }
             }
         }
-    };
+    );
 
     Ok(output)
 }

--- a/embedded-cli/Cargo.toml
+++ b/embedded-cli/Cargo.toml
@@ -21,12 +21,16 @@ help = ["embedded-cli-macros/help"]
 history = []
 del_is_bs = []
 
+async = ["embedded-cli-macros/async"]
+
 [dependencies]
 embedded-cli-macros = { version = "0.2.1", path = "../embedded-cli-macros", optional = true }
 
 bitflags = "2.5.0"
 embedded-io = "0.7.1"
 ufmt = "0.2.0"
+maybe-async-cfg2 = "0.3.0"
+embedded-io-async = "0.7.0"
 
 [dev-dependencies]
 regex = "1.10.4"

--- a/embedded-cli/src/builder.rs
+++ b/embedded-cli/src/builder.rs
@@ -4,6 +4,9 @@ use embedded_io::{Error, Write};
 
 use crate::{buffer::Buffer, cli::Cli, writer::EmptyWriter};
 
+#[cfg(feature = "async")]
+use crate::cli::CliAsync;
+
 pub const DEFAULT_CMD_LEN: usize = 40;
 pub const DEFAULT_HISTORY_LEN: usize = 100;
 pub const DEFAULT_PROMPT: &str = "$ ";
@@ -39,6 +42,11 @@ where
 {
     pub fn build(self) -> Result<Cli<W, E, CommandBuffer, HistoryBuffer>, E> {
         Cli::from_builder(self)
+    }
+
+    #[cfg(feature = "async")]
+    pub fn build_async(self) -> Result<CliAsync<W, E, CommandBuffer, HistoryBuffer>, E> {
+        CliAsync::from_builder(self)
     }
 
     pub fn command_buffer<B: Buffer>(

--- a/embedded-cli/src/cli.rs
+++ b/embedded-cli/src/cli.rs
@@ -18,6 +18,9 @@ use crate::{
     writer::{WriteExt, Writer},
 };
 
+#[cfg(feature = "async")]
+use crate::service::CommandProcessorAsync;
+
 #[cfg(feature = "autocomplete")]
 use crate::autocomplete::Request;
 
@@ -78,10 +81,7 @@ enum NavigateInput {
     Forward,
 }
 
-#[maybe(
-    sync(cfg(not(feature = "async")), keep_self),
-    async(feature = "async", keep_self)
-)]
+#[maybe(sync(keep_self), async(feature = "async"))]
 pub struct Cli<W: Write<Error = E>, E: Error, CommandBuffer: Buffer, HistoryBuffer: Buffer> {
     editor: Option<Editor<CommandBuffer>>,
     #[cfg(feature = "history")]
@@ -93,10 +93,7 @@ pub struct Cli<W: Write<Error = E>, E: Error, CommandBuffer: Buffer, HistoryBuff
     _ph: PhantomData<HistoryBuffer>,
 }
 
-#[maybe(
-    sync(cfg(not(feature = "async")), keep_self),
-    async(feature = "async", keep_self)
-)]
+#[maybe(sync(keep_self), async(feature = "async"))]
 impl<W, E, CommandBuffer, HistoryBuffer> Debug for Cli<W, E, CommandBuffer, HistoryBuffer>
 where
     W: Write<Error = E>,
@@ -114,8 +111,9 @@ where
 }
 
 #[maybe(
-    sync(cfg(not(feature = "async")), keep_self),
-    async(feature = "async", keep_self)
+    sync(keep_self),
+    async(feature = "async"),
+    idents(CommandProcessor(sync, async = "CommandProcessorAsync"))
 )]
 impl<W, E, CommandBuffer, HistoryBuffer> Cli<W, E, CommandBuffer, HistoryBuffer>
 where

--- a/embedded-cli/src/cli.rs
+++ b/embedded-cli/src/cli.rs
@@ -170,38 +170,6 @@ where
     /// command set and/or command processor.
     /// In process callback you can change some outside state
     /// so next calls will use different processor
-    #[cfg(not(feature = "async"))]
-    pub fn process_byte<C: Autocomplete + Help, P: CommandProcessor<W, E>>(
-        &mut self,
-        b: u8,
-        processor: &mut P,
-    ) -> Result<(), E> {
-        if let (Some(mut editor), Some(mut input_generator)) =
-            (self.editor.take(), self.input_generator.take())
-        {
-            let result = input_generator
-                .accept(b)
-                .map(|input| match input {
-                    Input::Control(control) => {
-                        self.on_control_input::<C, _>(&mut editor, control, processor)
-                    }
-                    Input::Char(text) => self.on_text_input(&mut editor, text),
-                })
-                .unwrap_or(Ok(()));
-
-            self.editor = Some(editor);
-            self.input_generator = Some(input_generator);
-            result
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Each call to process byte can be done with different
-    /// command set and/or command processor.
-    /// In process callback you can change some outside state
-    /// so next calls will use different processor
-    #[cfg(feature = "async")]
     pub async fn process_byte<C: Autocomplete + Help, P: CommandProcessor<W, E>>(
         &mut self,
         b: u8,

--- a/embedded-cli/src/cli.rs
+++ b/embedded-cli/src/cli.rs
@@ -28,6 +28,7 @@ use crate::{help::HelpRequest, service::HelpError};
 use crate::history::History;
 
 use embedded_io::{Error, Write};
+use maybe_async_cfg2::maybe;
 
 pub struct CliHandle<'a, W: Write<Error = E>, E: embedded_io::Error> {
     new_prompt: Option<&'static str>,
@@ -77,6 +78,10 @@ enum NavigateInput {
     Forward,
 }
 
+#[maybe(
+    sync(cfg(not(feature = "async")), keep_self),
+    async(feature = "async", keep_self)
+)]
 pub struct Cli<W: Write<Error = E>, E: Error, CommandBuffer: Buffer, HistoryBuffer: Buffer> {
     editor: Option<Editor<CommandBuffer>>,
     #[cfg(feature = "history")]
@@ -88,6 +93,10 @@ pub struct Cli<W: Write<Error = E>, E: Error, CommandBuffer: Buffer, HistoryBuff
     _ph: PhantomData<HistoryBuffer>,
 }
 
+#[maybe(
+    sync(cfg(not(feature = "async")), keep_self),
+    async(feature = "async", keep_self)
+)]
 impl<W, E, CommandBuffer, HistoryBuffer> Debug for Cli<W, E, CommandBuffer, HistoryBuffer>
 where
     W: Write<Error = E>,
@@ -104,6 +113,10 @@ where
     }
 }
 
+#[maybe(
+    sync(cfg(not(feature = "async")), keep_self),
+    async(feature = "async", keep_self)
+)]
 impl<W, E, CommandBuffer, HistoryBuffer> Cli<W, E, CommandBuffer, HistoryBuffer>
 where
     W: Write<Error = E>,
@@ -157,6 +170,7 @@ where
     /// command set and/or command processor.
     /// In process callback you can change some outside state
     /// so next calls will use different processor
+    #[cfg(not(feature = "async"))]
     pub fn process_byte<C: Autocomplete + Help, P: CommandProcessor<W, E>>(
         &mut self,
         b: u8,
@@ -174,6 +188,40 @@ where
                     Input::Char(text) => self.on_text_input(&mut editor, text),
                 })
                 .unwrap_or(Ok(()));
+
+            self.editor = Some(editor);
+            self.input_generator = Some(input_generator);
+            result
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Each call to process byte can be done with different
+    /// command set and/or command processor.
+    /// In process callback you can change some outside state
+    /// so next calls will use different processor
+    #[cfg(feature = "async")]
+    pub async fn process_byte<C: Autocomplete + Help, P: CommandProcessor<W, E>>(
+        &mut self,
+        b: u8,
+        processor: &mut P,
+    ) -> Result<(), E> {
+        if let (Some(mut editor), Some(mut input_generator)) =
+            (self.editor.take(), self.input_generator.take())
+        {
+            let result = if let Some(input) = input_generator.accept(b) {
+                Some(match input {
+                    Input::Control(control) => {
+                        self.on_control_input::<C, _>(&mut editor, control, processor)
+                            .await
+                    }
+                    Input::Char(text) => self.on_text_input(&mut editor, text),
+                })
+            } else {
+                None
+            }
+            .unwrap_or(Ok(()));
 
             self.editor = Some(editor);
             self.input_generator = Some(input_generator);
@@ -244,7 +292,7 @@ where
         Ok(())
     }
 
-    fn on_control_input<C: Autocomplete + Help, P: CommandProcessor<W, E>>(
+    async fn on_control_input<C: Autocomplete + Help, P: CommandProcessor<W, E>>(
         &mut self,
         editor: &mut Editor<CommandBuffer>,
         control: ControlInput,
@@ -259,7 +307,7 @@ where
                 let text = editor.text_mut();
 
                 let tokens = Tokens::new(text);
-                self.process_input::<C, _>(tokens, processor)?;
+                self.process_input::<C, _>(tokens, processor).await?;
 
                 editor.clear();
 
@@ -360,7 +408,7 @@ where
         Ok(())
     }
 
-    fn process_command<P: CommandProcessor<W, E>>(
+    async fn process_command<P: CommandProcessor<W, E>>(
         &mut self,
         command: RawCommand<'_>,
         handler: &mut P,
@@ -368,7 +416,7 @@ where
         let cli_writer = Writer::new(&mut self.writer);
         let mut handle = CliHandle::new(cli_writer);
 
-        let res = handler.process(&mut handle, command);
+        let res = handler.process(&mut handle, command).await;
 
         if let Some(prompt) = handle.new_prompt {
             self.prompt = prompt;
@@ -386,7 +434,7 @@ where
     }
 
     #[allow(clippy::extra_unused_type_parameters)]
-    fn process_input<C: Help, P: CommandProcessor<W, E>>(
+    async fn process_input<C: Help, P: CommandProcessor<W, E>>(
         &mut self,
         tokens: Tokens<'_>,
         handler: &mut P,
@@ -397,7 +445,7 @@ where
                 return self.process_help::<C>(request);
             }
 
-            self.process_command(command, handler)?;
+            self.process_command(command, handler).await?;
         };
 
         Ok(())

--- a/embedded-cli/src/command.rs
+++ b/embedded-cli/src/command.rs
@@ -53,6 +53,7 @@ impl<'a> RawCommand<'a> {
         self.name
     }
 
+    #[cfg(not(feature = "async"))]
     pub fn processor<
         W: Write<Error = E>,
         E: embedded_io::Error,
@@ -81,6 +82,45 @@ impl<'a> RawCommand<'a> {
                 raw: RawCommand<'a>,
             ) -> Result<(), ProcessError<'a, E>> {
                 (self.f)(cli, raw)?;
+                Ok(())
+            }
+        }
+
+        Processor {
+            f,
+            _ph: PhantomData,
+        }
+    }
+
+    #[cfg(feature = "async")]
+    pub fn processor<
+        W: Write<Error = E>,
+        E: embedded_io::Error,
+        F: AsyncFnMut(&mut CliHandle<'_, W, E>, RawCommand<'_>) -> Result<(), E>,
+    >(
+        f: F,
+    ) -> impl CommandProcessor<W, E> {
+        struct Processor<
+            W: Write<Error = E>,
+            E: embedded_io::Error,
+            F: AsyncFnMut(&mut CliHandle<'_, W, E>, RawCommand<'_>) -> Result<(), E>,
+        > {
+            f: F,
+            _ph: PhantomData<(W, E)>,
+        }
+
+        impl<
+                W: Write<Error = E>,
+                E: embedded_io::Error,
+                F: AsyncFnMut(&mut CliHandle<'_, W, E>, RawCommand<'_>) -> Result<(), E>,
+            > CommandProcessor<W, E> for Processor<W, E, F>
+        {
+            async fn process<'a>(
+                &mut self,
+                cli: &mut CliHandle<'_, W, E>,
+                raw: RawCommand<'a>,
+            ) -> Result<(), ProcessError<'a, E>> {
+                (self.f)(cli, raw).await?;
                 Ok(())
             }
         }

--- a/embedded-cli/src/command.rs
+++ b/embedded-cli/src/command.rs
@@ -9,6 +9,9 @@ use crate::{
     token::Tokens,
 };
 
+#[cfg(feature = "async")]
+use crate::service::CommandProcessorAsync;
+
 #[cfg(feature = "autocomplete")]
 use crate::autocomplete::{Autocompletion, Request};
 
@@ -53,7 +56,6 @@ impl<'a> RawCommand<'a> {
         self.name
     }
 
-    #[cfg(not(feature = "async"))]
     pub fn processor<
         W: Write<Error = E>,
         E: embedded_io::Error,
@@ -93,13 +95,13 @@ impl<'a> RawCommand<'a> {
     }
 
     #[cfg(feature = "async")]
-    pub fn processor<
+    pub fn processor_async<
         W: Write<Error = E>,
         E: embedded_io::Error,
         F: AsyncFnMut(&mut CliHandle<'_, W, E>, RawCommand<'_>) -> Result<(), E>,
     >(
         f: F,
-    ) -> impl CommandProcessor<W, E> {
+    ) -> impl CommandProcessorAsync<W, E> {
         struct Processor<
             W: Write<Error = E>,
             E: embedded_io::Error,
@@ -113,7 +115,7 @@ impl<'a> RawCommand<'a> {
                 W: Write<Error = E>,
                 E: embedded_io::Error,
                 F: AsyncFnMut(&mut CliHandle<'_, W, E>, RawCommand<'_>) -> Result<(), E>,
-            > CommandProcessor<W, E> for Processor<W, E, F>
+            > CommandProcessorAsync<W, E> for Processor<W, E, F>
         {
             async fn process<'a>(
                 &mut self,

--- a/embedded-cli/src/service.rs
+++ b/embedded-cli/src/service.rs
@@ -118,11 +118,7 @@ pub trait FromRaw<'a>: Sized {
     fn parse(raw: RawCommand<'a>) -> Result<Self, ParseError<'a>>;
 }
 
-#[maybe(
-    sync(cfg(not(feature = "async")), keep_self),
-    async(feature = "async", keep_self)
-)]
-#[allow(async_fn_in_trait)]
+#[maybe(sync(keep_self), async(feature = "async", allow(async_fn_in_trait)))]
 pub trait CommandProcessor<W: Write<Error = E>, E: embedded_io::Error> {
     async fn process<'a>(
         &mut self,
@@ -131,7 +127,6 @@ pub trait CommandProcessor<W: Write<Error = E>, E: embedded_io::Error> {
     ) -> Result<(), ProcessError<'a, E>>;
 }
 
-#[cfg(not(feature = "async"))]
 impl<W, E, F> CommandProcessor<W, E> for F
 where
     W: Write<Error = E>,
@@ -148,7 +143,7 @@ where
 }
 
 #[cfg(feature = "async")]
-impl<W, E, F> CommandProcessor<W, E> for F
+impl<W, E, F> CommandProcessorAsync<W, E> for F
 where
     W: Write<Error = E>,
     E: embedded_io::Error,

--- a/embedded-cli/src/service.rs
+++ b/embedded-cli/src/service.rs
@@ -1,4 +1,5 @@
 use embedded_io::Write;
+use maybe_async_cfg2::maybe;
 
 use crate::{arguments::FromArgumentError, cli::CliHandle, command::RawCommand};
 
@@ -117,14 +118,20 @@ pub trait FromRaw<'a>: Sized {
     fn parse(raw: RawCommand<'a>) -> Result<Self, ParseError<'a>>;
 }
 
+#[maybe(
+    sync(cfg(not(feature = "async")), keep_self),
+    async(feature = "async", keep_self)
+)]
+#[allow(async_fn_in_trait)]
 pub trait CommandProcessor<W: Write<Error = E>, E: embedded_io::Error> {
-    fn process<'a>(
+    async fn process<'a>(
         &mut self,
         cli: &mut CliHandle<'_, W, E>,
         raw: RawCommand<'a>,
     ) -> Result<(), ProcessError<'a, E>>;
 }
 
+#[cfg(not(feature = "async"))]
 impl<W, E, F> CommandProcessor<W, E> for F
 where
     W: Write<Error = E>,
@@ -137,5 +144,24 @@ where
         command: RawCommand<'a>,
     ) -> Result<(), ProcessError<'a, E>> {
         self(cli, command)
+    }
+}
+
+#[cfg(feature = "async")]
+impl<W, E, F> CommandProcessor<W, E> for F
+where
+    W: Write<Error = E>,
+    E: embedded_io::Error,
+    F: for<'a> AsyncFnMut(
+        &mut CliHandle<'_, W, E>,
+        RawCommand<'a>,
+    ) -> Result<(), ProcessError<'a, E>>,
+{
+    async fn process<'a>(
+        &mut self,
+        cli: &mut CliHandle<'_, W, E>,
+        command: RawCommand<'a>,
+    ) -> Result<(), ProcessError<'a, E>> {
+        self(cli, command).await
     }
 }

--- a/examples/desktop_async/Cargo.toml
+++ b/examples/desktop_async/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "desktop_async"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+embedded-cli = { path = "../../embedded-cli", features = ["async"] }
+embedded-io = "0.7.1"
+rand = "0.8.5"
+termion = "3.0.0"
+tokio = { version = "1.53.1", features = ["full"] }
+ufmt = "0.2.0"

--- a/examples/desktop_async/README.md
+++ b/examples/desktop_async/README.md
@@ -1,0 +1,10 @@
+# Desktop example
+
+This example used to quickly demonstrate CLI features without using actual device.
+
+# Running
+
+While inside `examples/desktop` directory:
+```shell
+cargo run
+```

--- a/examples/desktop_async/src/main.rs
+++ b/examples/desktop_async/src/main.rs
@@ -188,7 +188,7 @@ async fn main() {
         .writer(writer)
         .command_buffer(command_buffer)
         .history_buffer(history_buffer)
-        .build()
+        .build_async()
         .expect("Failed to build CLI");
 
     // Setting the CLI prompt
@@ -239,7 +239,7 @@ Use left and right to move inside input."
         for byte in bytes {
             cli.process_byte::<BaseCommand<'_>, _>(
                 byte,
-                &mut BaseCommand::processor(async |cli, command| match command {
+                &mut BaseCommand::processor_async(async |cli, command| match command {
                     BaseCommand::Led { id, command } => on_led(cli, &mut state, id, command),
                     BaseCommand::Adc { id, command } => on_adc(cli, &mut state, id, command),
                     BaseCommand::Status => on_status(cli, &mut state),

--- a/examples/desktop_async/src/main.rs
+++ b/examples/desktop_async/src/main.rs
@@ -1,0 +1,260 @@
+#![warn(rust_2018_idioms)]
+
+use embedded_cli::cli::{CliBuilder, CliHandle};
+use embedded_cli::codes;
+use embedded_cli::Command;
+use embedded_io::{ErrorType, Write};
+use std::convert::Infallible;
+use std::io::{stdin, stdout, Stdout, Write as _};
+use termion::event::{Event, Key};
+use termion::input::TermRead;
+use termion::raw::{IntoRawMode, RawTerminal};
+
+use ufmt::{uwrite, uwriteln};
+
+#[derive(Debug, Command)]
+enum BaseCommand<'a> {
+    /// Control LEDs
+    Led {
+        /// LED id
+        #[arg(long)]
+        id: u8,
+
+        #[command(subcommand)]
+        command: LedCommand,
+    },
+
+    /// Control ADC
+    Adc {
+        /// ADC id
+        #[arg(long)]
+        id: u8,
+
+        #[command(subcommand)]
+        command: AdcCommand<'a>,
+    },
+
+    /// Show some status
+    Status,
+
+    /// Stop CLI and exit
+    Exit,
+}
+
+#[derive(Debug, Command)]
+enum LedCommand {
+    /// Get current LED value
+    Get,
+
+    /// Set LED value
+    Set {
+        /// LED brightness
+        value: u8,
+    },
+}
+
+#[derive(Debug, Command)]
+enum AdcCommand<'a> {
+    /// Read ADC value
+    Read {
+        /// Print extra info
+        #[arg(short = 'V', long)]
+        verbose: bool,
+
+        /// Sample count (16 by default)
+        #[arg(long)]
+        samples: Option<u8>,
+
+        #[arg(long)]
+        sampler: &'a str,
+    },
+}
+
+pub struct Writer {
+    stdout: RawTerminal<Stdout>,
+}
+
+impl ErrorType for Writer {
+    type Error = Infallible;
+}
+
+impl Write for Writer {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.stdout.write_all(buf).unwrap();
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.stdout.flush().unwrap();
+        Ok(())
+    }
+}
+
+struct AppState {
+    led_brightness: [u8; 4],
+    num_commands: usize,
+    should_exit: bool,
+}
+
+fn on_led(
+    cli: &mut CliHandle<'_, Writer, Infallible>,
+    state: &mut AppState,
+    id: u8,
+    command: LedCommand,
+) -> Result<(), Infallible> {
+    state.num_commands += 1;
+
+    if id as usize > state.led_brightness.len() {
+        uwrite!(cli.writer(), "LED{} not found", id)?;
+    } else {
+        match command {
+            LedCommand::Get => {
+                uwrite!(
+                    cli.writer(),
+                    "Current LED{} brightness: {}",
+                    id,
+                    state.led_brightness[id as usize]
+                )?;
+            }
+            LedCommand::Set { value } => {
+                state.led_brightness[id as usize] = value;
+                uwrite!(cli.writer(), "Setting LED{} brightness to {}", id, value)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn on_adc(
+    cli: &mut CliHandle<'_, Writer, Infallible>,
+    state: &mut AppState,
+    id: u8,
+    command: AdcCommand<'_>,
+) -> Result<(), Infallible> {
+    state.num_commands += 1;
+
+    match command {
+        AdcCommand::Read {
+            verbose,
+            samples,
+            sampler,
+        } => {
+            let samples = samples.unwrap_or(16);
+            if verbose {
+                cli.writer().write_str("Performing sampling with ")?;
+                cli.writer().write_str(sampler)?;
+                uwriteln!(cli.writer(), "\nUsing {} samples", samples)?;
+            }
+            uwrite!(
+                cli.writer(),
+                "Current ADC{} readings: {}",
+                id,
+                rand::random::<u8>()
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn on_status(
+    cli: &mut CliHandle<'_, Writer, Infallible>,
+    state: &mut AppState,
+) -> Result<(), Infallible> {
+    state.num_commands += 1;
+    uwriteln!(cli.writer(), "Received: {}", state.num_commands)?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    let stdout = stdout().into_raw_mode().unwrap();
+
+    let writer = Writer { stdout };
+
+    const CMD_BUFFER_SIZE: usize = 1024;
+    const HISTORY_BUFFER_SIZE: usize = 2048;
+
+    // Creating static buffers for command history to avoid using stack memory
+    let (command_buffer, history_buffer) = unsafe {
+        static mut COMMAND_BUFFER: [u8; CMD_BUFFER_SIZE] = [0; CMD_BUFFER_SIZE];
+        static mut HISTORY_BUFFER: [u8; HISTORY_BUFFER_SIZE] = [0; HISTORY_BUFFER_SIZE];
+        #[allow(static_mut_refs)]
+        (COMMAND_BUFFER.as_mut(), HISTORY_BUFFER.as_mut())
+    };
+
+    // Setup CLI with command buffer, history buffer, and a writer for output
+    let mut cli = CliBuilder::default()
+        .writer(writer)
+        .command_buffer(command_buffer)
+        .history_buffer(history_buffer)
+        .build()
+        .expect("Failed to build CLI");
+
+    // Setting the CLI prompt
+    let _ = cli.set_prompt("main$ ");
+
+    // Create global state, that will be used for entire application
+    let mut state = AppState {
+        led_brightness: rand::random(),
+        num_commands: 0,
+        should_exit: false,
+    };
+
+    cli.write(|writer| {
+        uwrite!(
+            writer,
+            "Cli is running. Press 'Esc' to exit
+Type \"help\" for a list of commands.
+Use backspace and tab to remove chars and autocomplete.
+Use up and down for history navigation.
+Use left and right to move inside input."
+        )?;
+        Ok(())
+    })
+    .unwrap();
+
+    let stdin = stdin();
+    for c in stdin.events() {
+        let evt = c.unwrap();
+        let bytes = match evt {
+            Event::Key(Key::Esc) => break,
+            Event::Key(Key::Up) => vec![codes::ESCAPE, b'[', b'A'],
+            Event::Key(Key::Down) => vec![codes::ESCAPE, b'[', b'B'],
+            Event::Key(Key::Right) => vec![codes::ESCAPE, b'[', b'C'],
+            Event::Key(Key::Left) => vec![codes::ESCAPE, b'[', b'D'],
+            Event::Key(Key::BackTab) => vec![codes::TABULATION],
+            Event::Key(Key::Backspace) => vec![codes::BACKSPACE],
+            Event::Key(Key::Char(c)) => {
+                let mut buf = [0; 4];
+                c.encode_utf8(&mut buf).as_bytes().to_vec()
+            }
+            _ => continue,
+        };
+        // Process incoming byte
+        // Command type is specified for autocompletion and help
+        // Processor accepts closure where we can process parsed command
+        // we can use different command and processor with each call
+        // TODO: add example of login that uses different states
+        for byte in bytes {
+            cli.process_byte::<BaseCommand<'_>, _>(
+                byte,
+                &mut BaseCommand::processor(async |cli, command| match command {
+                    BaseCommand::Led { id, command } => on_led(cli, &mut state, id, command),
+                    BaseCommand::Adc { id, command } => on_adc(cli, &mut state, id, command),
+                    BaseCommand::Status => on_status(cli, &mut state),
+                    BaseCommand::Exit => {
+                        state.should_exit = true;
+                        cli.writer().write_str("Cli will shutdown now")
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+        }
+
+        if state.should_exit {
+            break;
+        }
+    }
+}


### PR DESCRIPTION
add async processor support using `maybe_async_cfg2` on feature "async".

I tried running memory.sh and I'm getting weird results, there are 200 more bytes in every measure in every test, but when comparing actual binary size with `cargo size` or `avr-size`, the main branch and this branch are equal.
I used this command(`avr-objcopy -O ihex binary.elf binary.hex`) to get the raw binary, and the two files(old and new) do not differ.